### PR TITLE
flatten records for training

### DIFF
--- a/chiron/utils/cmle_training_preprocess.pl
+++ b/chiron/utils/cmle_training_preprocess.pl
@@ -14,5 +14,5 @@ while ( my $line = <LABEL> ) {
   chomp $line;
   my ( $start, $end, $label ) = split /\s+/, $line;
   my @slice = @signal[ $start .. ($end-1) ];
-  print OUT $label, "\t", join( ",", @slice ), "\t", $base, "\n";
+  print OUT $label, "\t", $start, "\t", $end, "\t", scalar(@signal), "\t", join( ",", @slice ), "\t", $base, "\n";
 }

--- a/chiron/utils/cmle_training_preprocess.pl
+++ b/chiron/utils/cmle_training_preprocess.pl
@@ -1,19 +1,18 @@
 #!/usr/bin/perl
 use strict;
 my $base = shift @ARGV;
-
-if ( ! $base ) {
-  print STDERR "Usage: $0 [input prefix]\nwhere appending prefix with (.signal,.label) are readable paths\n";
+my $out  = shift @ARGV;
+if ( ! $base || ! $out ) {
+  print STDERR "Usage: $0 <input path prefix> <output path>\nwhere appending prefix with (.signal,.label) are readable paths\n";
   exit(1);
 }
-
 open( SIGNAL, "$base.signal" ) or die "Can't open .signal file: $!";
-open( LABEL,  "$base.label" )  or die "Can't open .label  file: $!";
+open( LABEL,  "$base.label"  ) or die "Can't open .label  file: $!";
+open( OUT,    ">$out"        ) or die "Can't write to '$out':   $!";
 my @signal = split /\s+/, <SIGNAL>;
-
 while ( my $line = <LABEL> ) {
   chomp $line;
   my ( $start, $end, $label ) = split /\s+/, $line;
   my @slice = @signal[ $start .. ($end-1) ];
-  print $label, "\t", join( ",", @slice ), "\n";
+  print OUT $label, "\t", join( ",", @slice ), "\t", $base, "\n";
 }

--- a/chiron/utils/cmle_training_preprocess.pl
+++ b/chiron/utils/cmle_training_preprocess.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/perl
+use strict;
+my $base = shift @ARGV;
+
+if ( ! $base ) {
+  print STDERR "Usage: $0 [input prefix]\nwhere appending prefix with (.signal,.label) are readable paths\n";
+  exit(1);
+}
+
+open( SIGNAL, "$base.signal" ) or die "Can't open .signal file: $!";
+open( LABEL,  "$base.label" )  or die "Can't open .label  file: $!";
+my @signal = split /\s+/, <SIGNAL>;
+
+while ( my $line = <LABEL> ) {
+  chomp $line;
+  my ( $start, $end, $label ) = split /\s+/, $line;
+  my @slice = @signal[ $start .. ($end-1) ];
+  print $label, "\t", join( ",", @slice ), "\n";
+}


### PR DESCRIPTION
preprocessing script to prepare .label and .signal inputs as one-line records for use in cloud ml engine training.