### PR TITLE
milestone 5: multiple gpu usage on google cloud ml engine

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 trainingInput:
   scaleTier: CUSTOM
-  masterType: standard_gpu
-  workerType: standard_gpu
+  masterType: complex_model_m_gpu
+  workerType: complex_model_m_gpu
   parameterServerType: large_model
-  workerCount: 2
-  parameterServerCount: 2
+  workerCount: 9
+  parameterServerCount: 3


### PR DESCRIPTION
I changed the config.yaml for enabling the multiple gpu on google cloud ml engine when training a new job.
Please check it and let me know when you have some trouble.

Best Regards
Lee