### PR TITLE
Fixed import for utils.progress

### DIFF
--- a/chiron/chiron_input.py
+++ b/chiron/chiron_input.py
@@ -20,7 +20,7 @@ from statsmodels import robust
 from six.moves import range
 from six.moves import zip
 import tensorflow as tf
-import utils.progress as progress
+from .utils import progress
 
 raw_labels = collections.namedtuple('raw_labels', ['start', 'length', 'base'])
 


### PR DESCRIPTION
When installing in a virtualenv, then running `chiron -h`:
```
  File "~/Chiron/.chiron/lib/python2.7/site-packages/chiron/chiron_input.py", line 23, in <module>
    import utils.progress as progress
ImportError: No module named utils.progress
```

Fixed this import error.