### PR TITLE
Update chiron_input.py

### DIFF
--- a/chiron/chiron_input.py
+++ b/chiron/chiron_input.py
@@ -20,7 +20,7 @@ from statsmodels import robust
 from six.moves import range
 from six.moves import zip
 import tensorflow as tf
-import utils.progress as progress
+import chiron.utils.progress as progress
 
 raw_labels = collections.namedtuple('raw_labels', ['start', 'length', 'base'])
 


### PR DESCRIPTION
as is caused ImportError when `chiron export -h` was executed. 

chiron export -h
Traceback (most recent call last):
  File "/usr/local/bin/chiron", line 11, in <module>
    load_entry_point('chiron==0.4.2', 'console_scripts', 'chiron')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 484, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2707, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2325, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2331, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/dist-packages/chiron/entry.py", line 13, in <module>
    from chiron import chiron_eval
  File "/usr/local/lib/python2.7/dist-packages/chiron/chiron_eval.py", line 20, in <module>
    from chiron.chiron_input import read_data_for_eval
  File "/usr/local/lib/python2.7/dist-packages/chiron/chiron_input.py", line 23, in <module>
    import utils.progress as progress
ImportError: No module named progress